### PR TITLE
fix: catch ObjectDisposedException in IconTintColorBehavior

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using Android.Graphics;
 using Android.Widget;
 using Microsoft.Maui.Platform;
@@ -52,16 +53,23 @@ public partial class IconTintColorBehavior
 			return;
 		}
 
-		switch (nativeView)
+		try
 		{
-			case ImageView image:
-				SetImageViewTintColor(image, color);
-				break;
-			case AButton button:
-				SetButtonTintColor(button, color);
-				break;
-			default:
-				throw new NotSupportedException($"{nameof(IconTintColorBehavior)} only currently supports Android.Widget.Button and {nameof(ImageView)}.");
+			switch (nativeView)
+			{
+				case ImageView image:
+					SetImageViewTintColor(image, color);
+					break;
+				case AButton button:
+					SetButtonTintColor(button, color);
+					break;
+				default:
+					throw new NotSupportedException($"{nameof(IconTintColorBehavior)} only currently supports Android.Widget.Button and {nameof(ImageView)}.");
+			}
+		}
+		catch (ObjectDisposedException)
+		{
+			Trace.WriteLine("IconTintColorBehavior is already disposed.");
 		}
 
 
@@ -121,17 +129,24 @@ public partial class IconTintColorBehavior
 			return;
 		}
 
-		switch (nativeView)
+		try
 		{
-			case ImageView image:
-				image.ClearColorFilter();
-				break;
-			case AButton button:
-				foreach (var drawable in button.GetCompoundDrawables())
-				{
-					drawable?.ClearColorFilter();
-				}
-				break;
+			switch (nativeView)
+			{
+				case ImageView image:
+					image.ClearColorFilter();
+					break;
+				case AButton button:
+					foreach (var drawable in button.GetCompoundDrawables())
+					{
+						drawable?.ClearColorFilter();
+					}
+					break;
+			}
+		}
+		catch (ObjectDisposedException)
+		{
+			Trace.WriteLine("IconTintColorBehavior is already disposed.");
 		}
 	}
 }


### PR DESCRIPTION
This PR ensures ObjectDisposedException is caught in IconTintColorBehavior, instead of bringing the whole app down. The previous PR related to this behavior reduced the frequency of the exceptions and prevented easy reproduction, but they still occur.

Definitely a suboptimal solution - ideally the use-after-dispose would be fixed in the first place, but this pattern occurs in other CommunityToolkit.Maui behaviors, e.g. [TouchBehavior](https://github.com/CommunityToolkit/Maui/blob/a10bfb9bbe3d10fcd63dc492098e6c67535d0f95/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/TouchBehavior.android.cs#L105), and should mitigate the crash completely.